### PR TITLE
move discount to checkout and add idempotent checkout

### DIFF
--- a/src/Services/Basket/Basket.API.IntegrationTests/Database/Redis/redisDataSeeder.cs
+++ b/src/Services/Basket/Basket.API.IntegrationTests/Database/Redis/redisDataSeeder.cs
@@ -34,7 +34,10 @@ public class RedisDataSeeder(IDistributedCache cache)
                     ProductId = x.ProduceId,
                     Quantity = x.Quantity
                 }).ToList(),
-                Version = cachedShoppingCart.Version
+                Version = cachedShoppingCart.Version,
+                PendingCheckoutOrderId = string.IsNullOrEmpty(cachedShoppingCart.PendingCheckoutOrderId)
+                    ? null
+                    : cachedShoppingCart.PendingCheckoutOrderId
             };
         }
 
@@ -53,7 +56,8 @@ public class RedisDataSeeder(IDistributedCache cache)
         {
             Username = basket.Username,
             TotalPrice = basket.TotalPrice.ToString(CultureInfo.InvariantCulture),
-            Version = basket.Version
+            Version = basket.Version,
+            PendingCheckoutOrderId = basket.PendingCheckoutOrderId ?? string.Empty
         };
         basketInDb.ShoppingCartItem.AddRange(basket.Items.Select(x => new Proto.ShoppingCartItem
         {

--- a/src/Services/Basket/Basket.API.IntegrationTests/Features/CheckoutBasket/CheckoutBasketTests.cs
+++ b/src/Services/Basket/Basket.API.IntegrationTests/Features/CheckoutBasket/CheckoutBasketTests.cs
@@ -10,13 +10,15 @@ public class CheckoutBasketTests : BaseEndpoint
     private readonly PostgresDataSeeder _postgresDataSeeder;
     private readonly RedisDataSeeder _redisDataSeeder;
     private readonly OrderCommandGiven _orderCommandGiven;
-    
+    private readonly DiscountGiven _discountGiven;
+
     public CheckoutBasketTests(ApiSpecification apiSpecification) : base(apiSpecification)
     {
         _postgresDataSeeder = _apiSpecification.PostgresDataSeeder;
         _redisDataSeeder = _apiSpecification.RedisDataSeeder;
         _client = _apiSpecification.HttpClient;
         _orderCommandGiven = _apiSpecification.CreateOrderCommandServerGiven();
+        _discountGiven = _apiSpecification.CreateDiscountServerGiven();
     }
     
     [Theory]
@@ -383,6 +385,7 @@ public class CheckoutBasketTests : BaseEndpoint
         await _postgresDataSeeder.SeedDatabaseAsync(shoppingCart, timeout);
         await _redisDataSeeder.AddShoppingCartAsync(shoppingCart, timeout);
 
+        _discountGiven.GetDiscountGiven("test product name");
         _orderCommandGiven.ReturningUnauthorized();
         
         // Act
@@ -416,6 +419,7 @@ public class CheckoutBasketTests : BaseEndpoint
         await _postgresDataSeeder.SeedDatabaseAsync(shoppingCart, timeout);
         await _redisDataSeeder.AddShoppingCartAsync(shoppingCart, timeout);
 
+        _discountGiven.GetDiscountGiven("test product name");
         _orderCommandGiven.ReturningForbidden();
         
         // Act
@@ -450,6 +454,7 @@ public class CheckoutBasketTests : BaseEndpoint
         await _postgresDataSeeder.SeedDatabaseAsync(shoppingCart, timeout);
         await _redisDataSeeder.AddShoppingCartAsync(shoppingCart, timeout);
 
+        _discountGiven.GetDiscountGiven("test product name");
         _orderCommandGiven.ReturningInternalServerError();
         
         // Act
@@ -484,6 +489,7 @@ public class CheckoutBasketTests : BaseEndpoint
         await _postgresDataSeeder.SeedDatabaseAsync(shoppingCart, timeout);
         await _redisDataSeeder.AddShoppingCartAsync(shoppingCart, timeout);
 
+        _discountGiven.GetDiscountGiven("test product name");
         _orderCommandGiven.ReturningBadRequest(new ValidationErrors(
             [
                 new ValidationError("order_id", "invalid order id")
@@ -527,8 +533,9 @@ public class CheckoutBasketTests : BaseEndpoint
 
         await _postgresDataSeeder.SeedDatabaseAsync(shoppingCart, timeout);
         await _redisDataSeeder.AddShoppingCartAsync(shoppingCart, timeout);
+        _discountGiven.GetDiscountGiven("test product name");
         _orderCommandGiven.ACreateOrderSuccessResponse(customerId, orderId);
-        
+
         // Act
         var response = await _client
             .SetFakeBearerToken(FakePermission.GetPermissions(
@@ -543,7 +550,54 @@ public class CheckoutBasketTests : BaseEndpoint
         result.ShouldNotBeNull();
         result.OrderId.ShouldBe(orderId);
     }
-    
+
+    [Theory, BasketRequestAutoData]
+    public async Task CheckoutBasket_when_basket_already_has_pending_order_id_reuses_it_on_retry(
+        CheckoutBasketRequest request)
+    {
+        // Arrange
+        var customerId = Guid.NewGuid().ToString();
+        var existingOrderId = Ulid.NewUlid().ToString();
+        var timeout = _apiSpecification.CreateTimeoutToken();
+
+        // Simulate a basket that had its checkout started but delete failed on a previous attempt.
+        var shoppingCart = new ShoppingCart
+        {
+            Items =
+            [
+                new ShoppingCartItem
+                {
+                    Color = "test color",
+                    Price = 10,
+                    ProductId = Ulid.NewUlid().ToString(),
+                    ProductName = "test product name",
+                    Quantity = 1
+                }
+            ],
+            Username = request.Username!,
+            PendingCheckoutOrderId = existingOrderId
+        };
+
+        await _postgresDataSeeder.SeedDatabaseAsync(shoppingCart, timeout);
+        await _redisDataSeeder.AddShoppingCartAsync(shoppingCart, timeout);
+        _discountGiven.GetDiscountGiven("test product name");
+        _orderCommandGiven.ACreateOrderSuccessResponse(customerId, existingOrderId);
+
+        // Act
+        var response = await _client
+            .SetFakeBearerToken(FakePermission.GetPermissions(
+                [Policies.BasketUserBasketCheckoutPermission],
+                sub: customerId,
+                username: request.Username))
+            .PostAsJsonAsync("api/v1/basket/customers/checkout", request, timeout);
+        var result = await response.Content.ReadFromJsonAsync<CheckoutBasketResponse>(timeout);
+
+        // Assert — same orderId must be reused, not a new one
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        result.ShouldNotBeNull();
+        result.OrderId.ShouldBe(existingOrderId);
+    }
+
     private async Task<HttpResponseMessage> CallSutAsync(CheckoutBasketRequest request, CancellationToken timeout)
     {
         return await _client

--- a/src/Services/Basket/Basket.API.IntegrationTests/Features/StoreBasket/StoreBasketTests.cs
+++ b/src/Services/Basket/Basket.API.IntegrationTests/Features/StoreBasket/StoreBasketTests.cs
@@ -9,7 +9,6 @@ namespace Basket.API.IntegrationTests.Features.StoreBasket;
 public class StoreBasketTests : BaseEndpoint
 {
     private HttpClient _client;
-    private DiscountGiven _discountGiven;
     private PostgresDataSeeder _postgresDataSeeder;
     private RedisDataSeeder _redisDataSeeder;
 
@@ -18,7 +17,6 @@ public class StoreBasketTests : BaseEndpoint
         _postgresDataSeeder = _apiSpecification.PostgresDataSeeder;
         _redisDataSeeder = _apiSpecification.RedisDataSeeder;
         _client = _apiSpecification.HttpClient;
-        _discountGiven = _apiSpecification.CreateDiscountServerGiven();
     }
     
     [Theory]
@@ -149,9 +147,8 @@ public class StoreBasketTests : BaseEndpoint
     [BasketRequestAutoData]
     public async Task StoreBasket_Valid_Request_Saves_Data_In_PostgresDb_And_Redis(StoreBasketRequest request)
     {
-        // Arrange 
+        // Arrange
         var token = _apiSpecification.CreateTimeoutToken();
-        _discountGiven.GetDiscountGiven(request.ShoppingCart!.Items!.FirstOrDefault()!.ProductName);
 
         // Act
         var result = await _client
@@ -183,7 +180,7 @@ public class StoreBasketTests : BaseEndpoint
     [BasketRequestAutoData]
     public async Task StoreBasket_Valid_Request_Saves_Data_With_Valid_TotalPrice(StoreBasketRequest request)
     {
-        // Arrange 
+        // Arrange
         var token = _apiSpecification.CreateTimeoutToken();
         var validRequest = new StoreBasketRequest(new BasketDtoRequest(request.ShoppingCart!.Username,
             new List<BasketItem>
@@ -191,8 +188,6 @@ public class StoreBasketTests : BaseEndpoint
                 request.ShoppingCart.Items!.FirstOrDefault()!,
                 request.ShoppingCart.Items!.FirstOrDefault()!
             }));
-
-        _discountGiven.GetDiscountGiven(request.ShoppingCart.Items!.FirstOrDefault()!.ProductName);
 
         // Act
         var result = await _client
@@ -212,13 +207,13 @@ public class StoreBasketTests : BaseEndpoint
         response.ShoppingCart.Username.ShouldBe(resultInPostgresDb.Username);
         JsonConvert.SerializeObject(response.ShoppingCart.Items)
             .ShouldBe(JsonConvert.SerializeObject(resultInPostgresDb.Items));
-        resultInPostgresDb.TotalPrice.ShouldBe(180);
+        resultInPostgresDb.TotalPrice.ShouldBe(200);
 
         var resultInRedis = await _redisDataSeeder.GetShoppingCartAsync(validRequest.ShoppingCart.Username, token);
         resultInRedis.ShouldNotBeNull();
         response.ShoppingCart.Username.ShouldBe(resultInRedis.Username);
         JsonConvert.SerializeObject(response.ShoppingCart.Items)
             .ShouldBe(JsonConvert.SerializeObject(resultInRedis.Items));
-        resultInRedis.TotalPrice.ShouldBe(180);
+        resultInRedis.TotalPrice.ShouldBe(200);
     }
 }

--- a/src/Services/Basket/Basket.API/Data/CachedBasketRepository.cs
+++ b/src/Services/Basket/Basket.API/Data/CachedBasketRepository.cs
@@ -93,7 +93,10 @@ internal class CachedBasketRepository(IBasketRepository repository, IDistributed
         {
             Username = basket.Username,
             Items = shoppingCartItems,
-            Version = basket.Version
+            Version = basket.Version,
+            PendingCheckoutOrderId = string.IsNullOrEmpty(basket.PendingCheckoutOrderId)
+                ? null
+                : basket.PendingCheckoutOrderId
         };
 
         return true;
@@ -105,7 +108,8 @@ internal class CachedBasketRepository(IBasketRepository repository, IDistributed
         {
             Username = basket.Username,
             TotalPrice = basket.TotalPrice.ToString(CultureInfo.InvariantCulture),
-            Version = basket.Version
+            Version = basket.Version,
+            PendingCheckoutOrderId = basket.PendingCheckoutOrderId ?? string.Empty
         };
         basketInDb.ShoppingCartItem.AddRange(basket.Items.Select(x => new Proto.ShoppingCartItem
         {

--- a/src/Services/Basket/Basket.API/Features/CheckoutBasket/CheckoutBasketHandler.cs
+++ b/src/Services/Basket/Basket.API/Features/CheckoutBasket/CheckoutBasketHandler.cs
@@ -1,5 +1,6 @@
 using Basket.API.ApiClient;
 using Basket.API.Features.CheckoutBasket.Commands.CreateOrder;
+using Discount;
 using eshop.Shared.CQRS.Command;
 using eshop.Shared.Logger;
 
@@ -14,13 +15,14 @@ public abstract record Result
     public record ApiClientError(FailureReasons FailureReason) : Result;
 }
 
-
 public class CheckoutBasketCommandHandler(
     IBasketRepository basketRepository,
-    CreateOrderCommand  createOrderCommand)
+    CreateOrderCommand createOrderCommand,
+    DiscountProtoService.DiscountProtoServiceClient discountClient)
     : ICommandHandler<CheckoutBasketCommand, Result>
 {
     private readonly ILogger _logger = Log.ForContext<CheckoutBasketCommandHandler>();
+
     public async Task<Result> Handle(CheckoutBasketCommand request, CancellationToken cancellationToken)
     {
         using var _ = LogContext.PushProperty(LogProperties.Username, request.CheckoutRequestModel?.Username);
@@ -33,8 +35,19 @@ public class CheckoutBasketCommandHandler(
         if (basket is null)
             return new Result.BasketNotFound();
 
+        // Persist the order ID before calling the Order Service so that a failed basket
+        // delete on the first attempt can be safely retried with the same idempotent ID.
+        if (basket.PendingCheckoutOrderId is null)
+        {
+            basket.PendingCheckoutOrderId = Ulid.NewUlid().ToString();
+            await basketRepository.StoreBasketAsync(basket, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Fetch discounts at checkout time so prices are always current.
+        var effectivePrices = await GetEffectivePricesAsync(basket.Items, cancellationToken).ConfigureAwait(false);
+
         var response = await createOrderCommand.CreateOrderAsync(
-            MapParameter(request.CheckoutRequestModel, basket), cancellationToken).ConfigureAwait(false);
+            MapParameter(request.CheckoutRequestModel, basket, effectivePrices), cancellationToken).ConfigureAwait(false);
 
         switch (response)
         {
@@ -42,7 +55,6 @@ public class CheckoutBasketCommandHandler(
                 _logger.Information("Basket was successfully checked out with {Id}", success.OrderId);
                 await basketRepository.DeleteBasketAsync(request.CheckoutRequestModel.Username!, cancellationToken)
                     .ConfigureAwait(false);
-            
                 return new Result.Success(success.OrderId);
             case CreateOrderCommandResult.Failure failure:
                 return new Result.ApiClientError(failure.Failures);
@@ -51,20 +63,37 @@ public class CheckoutBasketCommandHandler(
         }
     }
 
+    private async Task<IReadOnlyList<decimal>> GetEffectivePricesAsync(
+        IReadOnlyList<ShoppingCartItem> items, CancellationToken token)
+    {
+        var prices = new List<decimal>(items.Count);
+        foreach (var item in items)
+        {
+            var coupon = await discountClient.GetDiscountAsync(
+                    new GetDiscountRequest { ProductName = item.ProductName }, cancellationToken: token)
+                .ConfigureAwait(false);
+            prices.Add(item.Price - coupon.Amount);
+        }
+        return prices;
+    }
+
     private static CreteOrderCommandParameters MapParameter(
         CheckoutRequestModel checkoutRequestModel,
-        ShoppingCart shoppingCart)
+        ShoppingCart shoppingCart,
+        IReadOnlyList<decimal> effectivePrices)
     {
         return new CreteOrderCommandParameters
         {
-            OrderId = Ulid.NewUlid().ToString(),
+            OrderId = shoppingCart.PendingCheckoutOrderId,
             CustomerId = checkoutRequestModel.CustomerId!,
             OrderName = checkoutRequestModel.OrderName,
             ShippingAddress = MapAddress(checkoutRequestModel.BillingAddress!),
             BillingAddress = MapAddress(checkoutRequestModel.BillingAddress!),
             Payment = MapPayment(checkoutRequestModel.Payment!),
-            OrderItems = shoppingCart.Items.Select(x => new CreteOrderCommandParameters.ModuleOrderItem(
-                x.ProductId!, x.Quantity, x.Price)).ToList()
+            OrderItems = shoppingCart.Items
+                .Zip(effectivePrices, (item, price) => new CreteOrderCommandParameters.ModuleOrderItem(
+                    item.ProductId!, item.Quantity, price))
+                .ToList()
         };
     }
 
@@ -78,10 +107,9 @@ public class CheckoutBasketCommandHandler(
             payment.Cvv,
             payment.PaymentMethod);
     }
-    
+
     private static CreteOrderCommandParameters.ModuleAddress MapAddress(
-        CheckoutRequestModel.ModuleAddress address
-    )
+        CheckoutRequestModel.ModuleAddress address)
     {
         return new CreteOrderCommandParameters.ModuleAddress(
             address.Firstname,

--- a/src/Services/Basket/Basket.API/Features/StoreBasket/StoreBasketHandler.cs
+++ b/src/Services/Basket/Basket.API/Features/StoreBasket/StoreBasketHandler.cs
@@ -1,4 +1,3 @@
-using Discount;
 using eshop.Shared.CQRS.Command;
 using eshop.Shared.Logger;
 
@@ -8,22 +7,18 @@ public record StoreBasketCommand(BasketDtoRequest? ShoppingCart) : ICommand<Stor
 
 public record StoreBasketResult(BasketDtoResponse ShoppingCart);
 
-public class StoreBasketCommandHandler(
-    IBasketRepository basketRepository,
-    DiscountProtoService.DiscountProtoServiceClient discountClient)
+public class StoreBasketCommandHandler(IBasketRepository basketRepository)
     : ICommandHandler<StoreBasketCommand, StoreBasketResult>
 {
     private readonly ILogger _logger = Log.ForContext<StoreBasketCommandHandler>();
+
     public async Task<StoreBasketResult> Handle(StoreBasketCommand request, CancellationToken cancellationToken)
     {
         using var _ = LogContext.PushProperty(LogProperties.Username, request.ShoppingCart!.Username);
 
         _logger.Information("Store Basket for user");
-        
-        var shoppingCart = MapToShoppingCart(request.ShoppingCart!);
-        await ApplyDiscountAsync(shoppingCart.Items, cancellationToken)
-            .ConfigureAwait(false);
 
+        var shoppingCart = MapToShoppingCart(request.ShoppingCart!);
         var result = await basketRepository.StoreBasketAsync(shoppingCart, cancellationToken)
             .ConfigureAwait(false);
 
@@ -45,22 +40,9 @@ public class StoreBasketCommandHandler(
                 shoppingCart.TotalPrice));
     }
 
-    private async Task ApplyDiscountAsync(IReadOnlyList<ShoppingCartItem> items, CancellationToken token)
-    {
-        foreach (var item in items)
-        {
-            var coupon = await discountClient.GetDiscountAsync(
-                    new GetDiscountRequest { ProductName = item.ProductName }, cancellationToken: token)
-                .ConfigureAwait(false);
-
-            item.Price -= coupon.Amount;
-        }
-    }
-
     private static ShoppingCart MapToShoppingCart(BasketDtoRequest shoppingCart)
     {
-        return new ShoppingCart(
-            username: shoppingCart.Username)
+        return new ShoppingCart(username: shoppingCart.Username)
         {
             Items = shoppingCart.Items!.Select(x => new ShoppingCartItem
             {

--- a/src/Services/Basket/Basket.API/Models/ShoppingCart.cs
+++ b/src/Services/Basket/Basket.API/Models/ShoppingCart.cs
@@ -18,5 +18,8 @@ public class ShoppingCart
     public List<ShoppingCartItem> Items { get; set; } = [];
     public decimal TotalPrice => Items.Sum(x => x.Price * x.Quantity);
 
+    // Set before calling the Order Service; allows safe retries if basket delete fails.
+    public string? PendingCheckoutOrderId { get; set; }
+
     [Version] public int Version { get; set; }
 }

--- a/src/Services/Basket/Basket.API/Protos/basket.proto
+++ b/src/Services/Basket/Basket.API/Protos/basket.proto
@@ -9,6 +9,7 @@ message ShoppingCart{
   repeated ShoppingCartItem shoppingCartItem = 2;
   string totalPrice = 3;
   int32 version = 4;
+  string pendingCheckoutOrderId = 5;
 }
 
 message ShoppingCartItem{


### PR DESCRIPTION
Move discount application from StoreBasket to CheckoutBasket so prices are always fetched fresh at purchase time rather than being baked in stale at store time.

Add PendingCheckoutOrderId to ShoppingCart (persisted in Postgres and Redis via proto) so that if the basket delete fails after a successful order creation, a retry reuses the same order ID instead of creating a duplicate order.